### PR TITLE
Updated images used

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ You can now create the required keystores using the **setup.yaml** file. This wi
 $ kubectl create -f setup.yaml
 ```
 
+> You can find the Dockerfile and script for generating keystore in [containers/setup/ folder](containers/setup). You can build your own image using the provided Dockerfile.
+
 Once it is done, the Pod will not run again. You can delete the Pod after using `kubectl delete pod setup` (optional).
 
 If you want to confirm that the Pod has successfully imported the keystores, you can view the Pod's logs.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ $ kubectl create -f platform/registry.yaml
 
 To check if the control plane (controller and registry) is up:
 ```bash
-$ curl -w "%{http_code}" "<Public IP of your cluster>:31200/health" -o /dev/null
-$ curl -w "%{http_code}" "<Public IP of your kubernetes>:31300/uptime" -o /dev/null
+$ curl -sw "%{http_code}" "<Public IP of your cluster>:31200/health" -o /dev/null
+$ curl -sw "%{http_code}" "<Public IP of your kubernetes>:31300/uptime" -o /dev/null
 ```
 If both of them outputs 200, you can proceed to the next step.
 > Note: It can take around 1-2 minutes for the Pods to setup completely.

--- a/containers/setup/README.md
+++ b/containers/setup/README.md
@@ -1,0 +1,36 @@
+# Generate Keystore
+Dockerfile pulls from ibmjava image.
+```
+FROM ibmjava
+COPY gen-keystore.sh /tmp/gen-keystore.sh
+WORKDIR /tmp
+CMD bash ./gen-keystore.sh ${IP}
+```
+
+The provided script `gen-keystore.sh` generates a certificate for the app and requires an IP address as input. You will need to set an environment variable `IP` in your yaml file for creating the Pod.
+
+Example:
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: setup
+  labels:
+    app: gameon
+    tier: setup
+spec:
+  restartPolicy: Never
+  containers:
+  - name: setup
+    image: anthonyamanse/keystore # Replace this to your image name
+    env:
+      - name: IP
+        value: '169.47.241.213' # Replace this to your cluster's IP address
+    volumeMounts:
+    - name: keystore
+      mountPath: /tmp/keystore/
+  volumes:
+  - name: keystore
+    persistentVolumeClaim:
+      claimName: keystore-claim
+```

--- a/platform/controller.yaml
+++ b/platform/controller.yaml
@@ -39,7 +39,7 @@ spec:
         - name: A8_DATABASE_TYPE
           value: redis
         - name: A8_DATABASE_HOST
-          value: redis://redis:6379
+          value: redis://$(REDIS_SERVICE_HOST):$(REDIS_SERVICE_PORT)
         ports:
         - containerPort: 8080
           name: controller

--- a/platform/couchdb.yaml
+++ b/platform/couchdb.yaml
@@ -29,7 +29,7 @@ spec:
         tier: couchdb
     spec:
       containers:
-      - image: klaemo/couchdb:1.6.1
+      - image: couchdb:1.6.1
         name: couchdb
         ports:
         - containerPort: 5984

--- a/platform/kafka.yaml
+++ b/platform/kafka.yaml
@@ -29,7 +29,7 @@ spec:
         tier: kafka
     spec:
       containers:
-      - image: rshriram/kafka-0.9
+      - image: spotify/kafka
         name: kafka
         env:
         - name: ADVERTISED_HOST

--- a/platform/registry.yaml
+++ b/platform/registry.yaml
@@ -37,7 +37,7 @@ spec:
         - name: A8_STORE
           value: redis
         - name: A8_STORE_ADDRESS
-          value: redis:6379
+          value: $(REDIS_SERVICE_HOST):$(REDIS_SERVICE_PORT)
         ports:
         - containerPort: 8080
           name: registry


### PR DESCRIPTION
1. keystore image is using the Dockerfile in `/containers/setup`. It pulls from ibmjava and uses a script for generating a certificate.
2. couchdb.yaml is now using the official couchdb image (version 1.6.1).