### PR TITLE
Fix images used for core deployment

### DIFF
--- a/containers/gameon-proxy/haproxy-dev.cfg
+++ b/containers/gameon-proxy/haproxy-dev.cfg
@@ -34,7 +34,7 @@ frontend logstash-lumberjack
   default_backend logstash-lumberjack
 
 frontend frontend-ssl
-  bind *:443 ssl crt /keystore/proxy.pem
+  bind *:443 ssl crt /etc/ssl/proxy.pem
   mode http
   option httplog
 
@@ -94,7 +94,7 @@ backend room
   option httplog
   option httpchk HEAD / HTTP/1.1\r\nHost:localhost
   balance roundrobin
-  server room1 PLACEHOLDER_DOCKERHOST:30980 check
+  server room1 room:9080 check
 
 backend roomjs
   mode http
@@ -107,33 +107,33 @@ backend map
   option httplog
   option httpchk GET /map/v1/health HTTP/1.1\r\nHost:localhost
   balance roundrobin
-  server map1 PLACEHOLDER_DOCKERHOST:30947 ssl check check-ssl verify none
+  server map1 map:9443 ssl check check-ssl verify none
 
 backend mediator
   mode http
   option httplog
   balance roundrobin
-  server mediator1 PLACEHOLDER_DOCKERHOST:30946 ssl check check-ssl verify none
+  server mediator1 mediator:9443 ssl check check-ssl verify none
 
 backend auth
   mode http
   option httplog
   option httpchk GET /auth/health HTTP/1.1\r\nHost:localhost
   balance roundrobin
-  server auth1 PLACEHOLDER_DOCKERHOST:30949 ssl check check-ssl verify none
+  server auth1 auth:9443 ssl check check-ssl verify none
 
 backend player
   mode http
   option httplog
   balance roundrobin
-  server player1 PLACEHOLDER_DOCKERHOST:30943 ssl check check-ssl verify none
+  server player1 player:9443 ssl check check-ssl verify none
 
 backend static-content
   mode http
   option httpchk HEAD / HTTP/1.1\r\nHost:localhost
   option httplog
   balance roundrobin
-  server webapp1 PLACEHOLDER_DOCKERHOST:30880 check inter 1m
+  server webapp1 webapp:8080 check inter 1m
 
 backend logstash-lumberjack
   mode tcp

--- a/containers/gameon-proxy/startup.sh
+++ b/containers/gameon-proxy/startup.sh
@@ -46,24 +46,23 @@ if [ "$ETCDCTL_ENDPOINT" != "" ]; then
   export A8_CONTROLLER_POLL=$(etcdctl get /amalgam8/controllerPoll)
   JWT=$(etcdctl get /amalgam8/jwt)
 
-  sudo service rsyslog start 
+  sudo service rsyslog start
 
   echo Starting haproxy...
-  if [ -z "$A8_REGISTRY_URL" ]; then 
+  if [ -z "$A8_REGISTRY_URL" ]; then
     #no a8, just run haproxy.
     haproxy -f $PROXY_CONFIG
   else
     #a8, configure security, and run via sidecar.
-    if [ ! -z "$JWT" ]; then     
+    if [ ! -z "$JWT" ]; then
       export A8_REGISTRY_TOKEN=$JWT
       export A8_CONTROLLER_TOKEN=$JWT
-    fi  
+    fi
     exec a8sidecar --proxy haproxy -f $PROXY_CONFIG
-  fi  
+  fi
   echo HAProxy shut down
 else
   echo HAProxy will log to STDOUT--this is dev environment.
   sed -i s/PLACEHOLDER_PASSWORD/$ADMIN_PASSWORD/g /etc/haproxy/haproxy-dev.cfg
-  sed -i s/PLACEHOLDER_DOCKERHOST/$PROXY_DOCKER_HOST/g /etc/haproxy/haproxy-dev.cfg
   exec a8sidecar --proxy haproxy -f /etc/haproxy/haproxy-dev.cfg
 fi

--- a/core/auth.yaml
+++ b/core/auth.yaml
@@ -37,7 +37,8 @@ spec:
         tier: auth
     spec:
       containers:
-      - image: gameontext/gameon-auth
+      - image: anthonyamanse/gameon-auth:latest
+        imagePullPolicy: Always
         name: auth
         env:
           - name: service_map

--- a/core/map.yaml
+++ b/core/map.yaml
@@ -37,7 +37,8 @@ spec:
         tier: map
     spec:
       containers:
-      - image: gameontext/gameon-map
+      - image: anthonyamanse/gameon-map:latest
+        imagePullPolicy: Always
         name: map
         env:
           - name: service_map

--- a/core/mediator.yaml
+++ b/core/mediator.yaml
@@ -37,7 +37,8 @@ spec:
         tier: mediator
     spec:
       containers:
-      - image: gameontext/gameon-mediator
+      - image: anthonyamanse/gameon-mediator:latest
+        imagePullPolicy: Always
         name: mediator
         env:
           - name: service_map

--- a/core/player.yaml
+++ b/core/player.yaml
@@ -42,7 +42,8 @@ spec:
         tier: player
     spec:
       containers:
-      - image: gameontext/gameon-player
+      - image: anthonyamanse/gameon-player:latest
+        imagePullPolicy: Always
         name: player
         env:
           - name: service_map

--- a/core/proxy.yaml
+++ b/core/proxy.yaml
@@ -42,7 +42,8 @@ spec:
         tier: proxy
     spec:
       containers:
-      - image: anthonyamanse/gameon-proxy
+      - image: anthonyamanse/gameon-proxy:0.1
+        imagePullPolicy: Always
         name: proxy
         env:
           - name: service_map

--- a/core/room.yaml
+++ b/core/room.yaml
@@ -37,7 +37,8 @@ spec:
         tier: room
     spec:
       containers:
-      - image: gameontext/gameon-room
+      - image: anthonyamanse/gameon-room:latest
+        imagePullPolicy: Always
         name: room
         env:
           - name: service_map

--- a/core/webapp.yaml
+++ b/core/webapp.yaml
@@ -32,7 +32,8 @@ spec:
         tier: webapp
     spec:
       containers:
-      - image: gameontext/gameon-webapp
+      - image: anthonyamanse/gameon-webapp:latest
+        imagePullPolicy: Always
         name: webapp
         env:
           - name: service_map

--- a/local-volume.yaml
+++ b/local-volume.yaml
@@ -17,6 +17,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: keystore-claim
+  annotations:  # comment line if you want to use a StorageClass
+    # or specify which StorageClass
+    volume.beta.kubernetes.io/storage-class: ""   # comment line if you
+    # want to use a StorageClass or specify which StorageClass
   labels:
     app: gameon
 spec:


### PR DESCRIPTION
Images from gameontext dockerhub repo removed images that were using amalgam8 sidecars.

This fix replaces the image in the deployment to use built images from old source that are still using a8 sidecars.

The gameon-proxy configuration is also modified to use kubernetes service names and port for core services.

Local volume is configured for PersistentVolumeClaim to use user-created PersistentVolume.